### PR TITLE
Adding an extra test for Simple example 

### DIFF
--- a/src/main/scala/examples/ExampleApb2CSTrgt.scala
+++ b/src/main/scala/examples/ExampleApb2CSTrgt.scala
@@ -16,6 +16,7 @@ class ExampleApb2CSTrgt() extends Module {
   val DATA_W = 32
 
   val t = Module(new Apb2CSTrgt(
+    ADDR_W = ADDR_W,
     DATA_W = DATA_W,
     REG_DESC_JSON = "src/main/json/Example.json",
     VERBOSE = true,

--- a/src/main/scala/examples/SimpleApb2CSTrgt.scala
+++ b/src/main/scala/examples/SimpleApb2CSTrgt.scala
@@ -16,6 +16,7 @@ class SimpleApb2CSTrgt() extends Module {
   val DATA_W = 32
 
   val t = Module(new Apb2CSTrgt(
+    ADDR_W = ADDR_W,
     DATA_W = DATA_W,
     REG_DESC_JSON = "src/main/json/Simple.json",
     VERBOSE = true,

--- a/src/test/scala/AmbaUnitTester.scala
+++ b/src/test/scala/AmbaUnitTester.scala
@@ -48,6 +48,7 @@ abstract class AmbelUnitTester(DATA_W: Int = 32) extends BaseUnitTester {
     t.req.pStrb.poke(0.U)
     ApbXfer(t, pclk)
     t.rsp.pRData.peek()
+    t.rsp.pSlvErr.peek()
   }
 
   def ApbReadExpect(t: Apb2IO, pclk: Clock, pAddr: Int, pRData: Int) = {
@@ -60,6 +61,11 @@ abstract class AmbelUnitTester(DATA_W: Int = 32) extends BaseUnitTester {
     t.req.pStrb.poke(0.U)
     ApbXfer(t, pclk)
     t.rsp.pRData.expect(pRDataStr.U)
+    t.rsp.pSlvErr.expect(false.B)
+  }
+
+  def ApbExpectSlvErr(t: Apb2IO) = {
+    t.rsp.pSlvErr.expect(true.B)
   }
 
   def ApbWriteStrb(t: Apb2IO, pclk: Clock, pAddr: Int, pWData: Int, pStrb: Int) = {

--- a/src/test/scala/Apb2CSTrgtUnitTest.scala
+++ b/src/test/scala/Apb2CSTrgtUnitTest.scala
@@ -16,7 +16,7 @@ class Apb2CSTrgt32BitRWRegsTestWrapper(val VERBOSE: Boolean = false) extends Mod
   val ADDR_W = 32
   val DATA_W = 32
 
-  val t = Module(new Apb2CSTrgt(32, "src/test/json/32BitRwRegs.json", VERBOSE))
+  val t = Module(new Apb2CSTrgt(ADDR_W, DATA_W, "src/test/json/32BitRwRegs.json", VERBOSE))
 
   val io = IO(new Bundle {
     val apb2T = new Apb2IO(ADDR_W, DATA_W)
@@ -48,7 +48,7 @@ class Apb2CSTrgt8GoBitWORegsTestWrapper(val VERBOSE: Boolean = false) extends Mo
   val ADDR_W = 32
   val DATA_W = 32
 
-  val t = Module(new Apb2CSTrgt(32, "src/test/json/8GoBitWoRegs.json", VERBOSE))
+  val t = Module(new Apb2CSTrgt(ADDR_W, DATA_W, "src/test/json/8GoBitWoRegs.json", VERBOSE))
 
   val io = IO(new Bundle {
     val apb2T = new Apb2IO(ADDR_W, DATA_W)
@@ -94,10 +94,11 @@ class Apb2CSTrgtUnitTester extends AmbelUnitTester {
     * versioned, by elaboration of the parameterized Apb2CSTrgt Module with the
     * corresponding JSON file and GEN_BUNDLE=true.
     */
+  val ADDR_W = 32
   val DATA_W = 32
 
   it should "write then read consecutive addresses of register file APB target back to back" in {
-    test(new Apb2CSTrgt(DATA_W, "src/test/json/RegFile.json")).withAnnotations(annos) { dut =>
+    test(new Apb2CSTrgt(ADDR_W, DATA_W, "src/test/json/RegFile.json")).withAnnotations(annos) { dut =>
       dut.clock.step(4)
 
       val NUM_REGS = dut.NUM_REGS
@@ -114,7 +115,7 @@ class Apb2CSTrgtUnitTester extends AmbelUnitTester {
   }
 
   it should "write all addresses of register file APB target in sequence then read all back" in {
-    test(new Apb2CSTrgt(DATA_W, "src/test/json/RegFile.json")).withAnnotations(annos) { dut =>
+    test(new Apb2CSTrgt(ADDR_W, DATA_W, "src/test/json/RegFile.json")).withAnnotations(annos) { dut =>
       dut.clock.step(4)
 
       val NUM_REGS = dut.NUM_REGS
@@ -140,7 +141,7 @@ class Apb2CSTrgtUnitTester extends AmbelUnitTester {
   }
 
   it should "test write strobes of register file APB target" in {
-    test(new Apb2CSTrgt(DATA_W, "src/test/json/RegFile.json")).withAnnotations(annos) { dut =>
+    test(new Apb2CSTrgt(ADDR_W, DATA_W, "src/test/json/RegFile.json")).withAnnotations(annos) { dut =>
       dut.clock.step(4)
 
       val NUM_REGS = dut.NUM_REGS

--- a/src/test/scala/Apb2NetUnitTest.scala
+++ b/src/test/scala/Apb2NetUnitTest.scala
@@ -14,15 +14,15 @@ class Apb2NetTestHarness(
   val NUM_INIT: Int = 1, val NUM_TARG: Int = 2,
   val TARGET_SIZES: Array[Int] = Array(1,1)) extends Module {
 
-  val DATA_WIDTH = 32
+  val DATA_W = 32
   val NUM_REGS = 16
-  val ADDR_WIDTH = 32
+  val ADDR_W = 32
   val io = IO(new Bundle {
-    val apb2i = Vec(NUM_INIT, new Apb2IO(ADDR_WIDTH, DATA_WIDTH))
+    val apb2i = Vec(NUM_INIT, new Apb2IO(ADDR_W, DATA_W))
   })
 
   val Apb2Net_i = Module(new Apb2Net(NUM_INIT=NUM_INIT, NUM_TARG=NUM_TARG, TARGET_SIZES=TARGET_SIZES))
-  val Apb2TrgtArr_i = Seq.fill(NUM_TARG)(Module(new Apb2RegFile(NUM_REGS, DATA_WIDTH)))
+  val Apb2TrgtArr_i = Seq.fill(NUM_TARG)(Module(new Apb2RegFile(NUM_REGS, DATA_W)))
 
   Apb2Net_i.io.apb2i <> io.apb2i
 
@@ -58,7 +58,7 @@ class Apb2NetUnitTester extends AmbelUnitTester {
       dut.clock.step(4)
 
       // Discover APB network topology
-      val DATA_WIDTH = dut.DATA_WIDTH
+      val DATA_W = dut.DATA_W
       val NUM_REGS = dut.NUM_REGS
       val NUM_INIT = dut.NUM_INIT
       val NUM_TARG = dut.NUM_TARG
@@ -79,7 +79,7 @@ class Apb2NetUnitTester extends AmbelUnitTester {
         for (t <- 0 until NUM_TARG) {
           for (r <- 0 until NUM_REGS) {
             val data = rand.nextInt
-            val addr = targetBases(t) + r * DATA_WIDTH / 8
+            val addr = targetBases(t) + r * DATA_W / 8
             ApbWriteStrb(dut.io.apb2i(i), dut.clock, addr, data, 0xf)
             ApbReadExpect(dut.io.apb2i(i), dut.clock, addr, data)
           }
@@ -96,7 +96,7 @@ class Apb2NetUnitTester extends AmbelUnitTester {
       dut.clock.step(4)
 
       // Discover APB network topology
-      val DATA_WIDTH = dut.DATA_WIDTH
+      val DATA_W = dut.DATA_W
       val NUM_REGS = dut.NUM_REGS
       val NUM_INIT = dut.NUM_INIT
       val NUM_TARG = dut.NUM_TARG
@@ -108,14 +108,14 @@ class Apb2NetUnitTester extends AmbelUnitTester {
       fork {
         for (r <- 0 until NUM_REGS by 2) {
           val data = rand.nextInt
-          val addr = BASE_ADDR + r * DATA_WIDTH / 8
+          val addr = BASE_ADDR + r * DATA_W / 8
           evenDataSeq += data
           ApbWriteStrb(dut.io.apb2i(0), dut.clock, addr, data, 0xf)
         }
       }.fork {
         for (r <- 1 until NUM_REGS by 2) {
           val data = rand.nextInt
-          val addr = BASE_ADDR + r * DATA_WIDTH / 8
+          val addr = BASE_ADDR + r * DATA_W / 8
           oddDataSeq += data
           ApbWriteStrb(dut.io.apb2i(1), dut.clock, addr, data, 0xf)
         }
@@ -130,11 +130,11 @@ class Apb2NetUnitTester extends AmbelUnitTester {
 
       // Read all registers back in order via each initiator in turn
       for (r <- 0 until NUM_REGS) {
-        val addr = BASE_ADDR + r * DATA_WIDTH / 8
+        val addr = BASE_ADDR + r * DATA_W / 8
         ApbReadExpect(dut.io.apb2i(0), dut.clock, addr, dataSeq(r))
       }
       for (r <- 0 until NUM_REGS) {
-        val addr = BASE_ADDR + r * DATA_WIDTH / 8
+        val addr = BASE_ADDR + r * DATA_W / 8
         ApbReadExpect(dut.io.apb2i(1), dut.clock, addr, dataSeq(r))
       }
 

--- a/src/test/scala/SimpleApb2CSTrgtUnitTest.scala
+++ b/src/test/scala/SimpleApb2CSTrgtUnitTest.scala
@@ -49,4 +49,27 @@ class SimpleApb2CSTrgtUnitTester extends AmbelUnitTester {
     }
   }
 
+  it should "respond with PSLVERR on access to unmapped address" in {
+    test(new SimpleApb2CSTrgt()).withAnnotations(annos) { dut =>
+      dut.clock.step(4)
+
+      // Following address is out of range - only 2 registers mapped to lowest offsets (i.e. 0x0 and 0x4)
+      val addr = 0x8
+      val data = rand.nextInt & 0xff
+
+      // Attempt write out of range - expect PSLVERR
+      ApbWriteStrb(dut.io.apb2T, dut.clock, addr, data, 0xf)
+      ApbExpectSlvErr(dut.io.apb2T)
+
+      // Read and check reset value of RW register
+      ApbReadExpect(dut.io.apb2T, dut.clock, 0x0, 0x0)
+
+      // Attempt read out of range - expect PSLVERR
+      ApbRead(dut.io.apb2T, dut.clock, addr)
+      ApbExpectSlvErr(dut.io.apb2T)
+
+      dut.clock.step(4)
+    }
+  }
+
 }


### PR DESCRIPTION
## Describe your changes
Adding an extra test for Simple example Which attempts to write and read an unmapped register and expects a PSLVERR response. 
Also making ADDR_W and explicit parameter for Apb2CSTrgt rather than derived. This is
actually required for the implementation of PSLVERR above. Also making
parameter names for ADDR_W and DATA_W in Apb2Net consistent with other
Modules in collection.

## Issue number and link
Fixes [#19](https://github.com/richmorj/ambel/issues/19)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have followed the coding guidelines
- [x] I have added tests
