### PR TITLE
Adding unit test for RO bit fields

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,10 +5,10 @@
 
 ThisBuild / scalaVersion     := "2.12.13"
 ThisBuild / version          := "0.1.0"
-ThisBuild / organization     := "lz.tech"
+ThisBuild / organization     := "substate.tech"
 
 val circeVersion = "0.7.0"
-val chisel3Version = "3.5.3"
+val chisel3Version = "3.5.4"
 val chiseltestVersion = "0.5.1"
 val chiselVerifyVersion = "0.2.0"
 
@@ -16,7 +16,7 @@ libraryDependencies += "io.github.chiselverify" % "chiselverify" % "0.2.0"
 
 lazy val root = (project in file("."))
   .settings(
-    name := "lz.ambel",
+    name := "substate.ambel",
     libraryDependencies ++= Seq(
       "edu.berkeley.cs" %% "chisel3" % chisel3Version,
       "edu.berkeley.cs" %% "chiseltest" % chiseltestVersion % "test",

--- a/src/main/scala/Apb2CSTrgt.scala
+++ b/src/main/scala/Apb2CSTrgt.scala
@@ -615,5 +615,5 @@ class Apb2CSTrgt(
   */
 // $COVERAGE-OFF$
 object Apb2CSTrgtDriver extends App {
-  (new ChiselStage).execute(args, Seq(ChiselGeneratorAnnotation(() => new Apb2CSTrgt(32, 32, "src/main/json/Example.json", true, true))))
+  (new ChiselStage).execute(args, Seq(ChiselGeneratorAnnotation(() => new Apb2CSTrgt(32, 32, "src/test/json/8BitRoStatusRegs.json", true, true))))
 }

--- a/src/test/json/8BitRoStatusRegs.json
+++ b/src/test/json/8BitRoStatusRegs.json
@@ -1,0 +1,30 @@
+{
+ "regMap": [
+  {
+   "offset": 0,
+   "name": "REG_ZERO", "typeRef": "REG_RO_8_STATUS"
+  },
+  {
+   "offset": 4,
+   "name": "REG_ONE", "typeRef": "REG_RO_8_STATUS"
+  },
+  {
+   "offset": 8,
+   "name": "REG_TWO", "typeRef": "REG_RO_8_STATUS"
+  },
+  {
+   "offset": 12,
+   "name": "REG_THREE", "typeRef": "REG_RO_8_STATUS"
+  }
+ ],
+ "regTypes": [
+  {
+   "typeRef": "REG_RO_8_STATUS",
+   "width": 32,
+   "fields": [
+    {"bits": [7, 0], "name": "STATUS_BITS", "mode": "RO"}
+   ],
+   "comment": "8 status bits, read only, writing has no effect."
+  }
+ ]
+}

--- a/src/test/scala/8BitRoStatusRegs.scala
+++ b/src/test/scala/8BitRoStatusRegs.scala
@@ -1,0 +1,15 @@
+// See README.md for license details.
+package ambel
+
+import chisel3._
+
+/** =Bundles for Connection to Apb2CSTrgt(REG_DESC_JSON="src/test/json/8BitRoStatusRegs.json")=
+  *
+  * THIS IS AUTO-GENERATED CODE - DO NOT MODIFY BY HAND!
+  */
+class _8BitRoStatusRegsRoVec_ extends Bundle {
+  val RegZero_StatusBits = UInt(8.W)
+  val RegOne_StatusBits = UInt(8.W)
+  val RegTwo_StatusBits = UInt(8.W)
+  val RegThree_StatusBits = UInt(8.W)
+}

--- a/src/test/scala/AmbaUnitTester.scala
+++ b/src/test/scala/AmbaUnitTester.scala
@@ -48,7 +48,6 @@ abstract class AmbelUnitTester(DATA_W: Int = 32) extends BaseUnitTester {
     t.req.pStrb.poke(0.U)
     ApbXfer(t, pclk)
     t.rsp.pRData.peek()
-    t.rsp.pSlvErr.peek()
   }
 
   def ApbReadExpect(t: Apb2IO, pclk: Clock, pAddr: Int, pRData: Int) = {


### PR DESCRIPTION
## Describe your changes
Adding very simple JSON config for a target with 4 registers each holding a single 8 bit RO field. Comprehensive testing of same including checking that writes have no effect and driving random values into the RO inputs.

## Issue number and link
Fixes [#](https://github.com/substate-tech/ambel/issues/8)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have followed the coding guidelines
- [x] I have added tests
