### PR TITLE
9 add apb2cstrgt unit test for w1c bits

### DIFF
--- a/src/main/scala/Apb2CSTrgt.scala
+++ b/src/main/scala/Apb2CSTrgt.scala
@@ -615,5 +615,5 @@ class Apb2CSTrgt(
   */
 // $COVERAGE-OFF$
 object Apb2CSTrgtDriver extends App {
-  (new ChiselStage).execute(args, Seq(ChiselGeneratorAnnotation(() => new Apb2CSTrgt(32, 32, "src/test/json/8BitRoStatusRegs.json", true, true))))
+  (new ChiselStage).execute(args, Seq(ChiselGeneratorAnnotation(() => new Apb2CSTrgt(32, 32, "src/main/json/Example.json", true, true))))
 }

--- a/src/test/json/8BitW1CRegs.json
+++ b/src/test/json/8BitW1CRegs.json
@@ -1,0 +1,30 @@
+{
+ "regMap": [
+  {
+   "offset": 0,
+   "name": "REG_ZERO", "typeRef": "REG_W1C_8_STATUS"
+  },
+  {
+   "offset": 4,
+   "name": "REG_ONE", "typeRef": "REG_W1C_8_STATUS"
+  },
+  {
+   "offset": 8,
+   "name": "REG_TWO", "typeRef": "REG_W1C_8_STATUS"
+  },
+  {
+   "offset": 12,
+   "name": "REG_THREE", "typeRef": "REG_W1C_8_STATUS"
+  }
+ ],
+ "regTypes": [
+  {
+   "typeRef": "REG_W1C_8_STATUS",
+   "width": 32,
+   "fields": [
+    {"bits": [7, 0], "name": "W1C_BITS", "mode": "W1C"}
+   ],
+   "comment": "8 active HIGH write-1-to-clear status bits, '0' out of reset, set to '1' via Module inputs pulsing HIGH, cleared by writing '1' to same bits via corresponding register."
+  }
+ ]
+}

--- a/src/test/scala/8BitW1CRegs.scala
+++ b/src/test/scala/8BitW1CRegs.scala
@@ -1,0 +1,15 @@
+// See README.md for license details.
+package ambel
+
+import chisel3._
+
+/** =Bundles for Connection to Apb2CSTrgt(REG_DESC_JSON="src/test/json/8BitW1CRegs.json")=
+  *
+  * THIS IS AUTO-GENERATED CODE - DO NOT MODIFY BY HAND!
+  */
+class _8BitW1CRegsWcVec_ extends Bundle {
+  val RegZero_StatusBits = UInt(8.W)
+  val RegOne_StatusBits = UInt(8.W)
+  val RegTwo_StatusBits = UInt(8.W)
+  val RegThree_StatusBits = UInt(8.W)
+}

--- a/src/test/scala/Apb2CSTrgtUnitTest.scala
+++ b/src/test/scala/Apb2CSTrgtUnitTest.scala
@@ -88,6 +88,31 @@ class Apb2CSTrgt8BitROStatusORegsTestWrapper(val VERBOSE: Boolean = false) exten
   t.io.roVec(3) := io.ro.RegThree_StatusBits
 }
 
+/** =Apb2CSTrgt8BitW1CRegsTestWrapper=
+  *
+  * Wraps instance of Apb2CSTrgt parameterized with 8BitW1CRegs.json with
+  * register W1C Input Vec connected to auto-generated Bundle matching specified
+  * bitfield names
+  */
+class Apb2CSTrgt8BitW1CRegsTestWrapper(val VERBOSE: Boolean = false) extends Module {
+  val ADDR_W = 32
+  val DATA_W = 32
+
+  val t = Module(new Apb2CSTrgt(ADDR_W, DATA_W, "src/test/json/8BitW1CRegs.json", VERBOSE))
+
+  val io = IO(new Bundle {
+    val apb2T = new Apb2IO(ADDR_W, DATA_W)
+    val wc = Input(new _8BitW1CRegsWcVec_)
+  })
+
+  t.io.apb2T <> io.apb2T
+
+  t.io.wcVec(0) := io.wc.RegZero_StatusBits
+  t.io.wcVec(1) := io.wc.RegOne_StatusBits
+  t.io.wcVec(2) := io.wc.RegTwo_StatusBits
+  t.io.wcVec(3) := io.wc.RegThree_StatusBits
+}
+
 /** =Apb2CSTrgt Unit Tester=
   * Run this Specification as follows...
   * From within sbt use:


### PR DESCRIPTION
## Describe your changes
Added simple test for W1C bits. JSON reg map defines 4 registers, each with a single 8 bit W1C field. Test checks initial value, pulses the inputs connected to each register with 0xff, checks all the bits have been set to '1' by reading the registers and expecting 0xff, clears each bit individually by writing a '1', checking that the bit has been cleared as it goes.

## Issue number and link
Fixes [#9](https://github.com/richmorj/ambel/issues/9)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have followed the coding guidelines
- [x] I have added tests
