### PR TITLE
Adding tests for pStrb functionality when bit-fields straddle bytes.

### DIFF
--- a/src/test/json/MisalignedRWRegs.json
+++ b/src/test/json/MisalignedRWRegs.json
@@ -1,0 +1,46 @@
+{
+ "regMap": [
+  {
+   "offset": 0,
+   "name": "REG_ZERO", "typeRef": "REG_RW_WITH_BITFIELDS_STRADDLING_BYTE_BOUNDARIES_0",
+   "comment": "32 bit register with RW bitfields straddling byte boundaries"
+  },
+  {
+   "offset": 4,
+   "name": "REG_TWO", "typeRef": "REG_RW_WITH_BITFIELDS_STRADDLING_BYTE_BOUNDARIES_1",
+   "comment": "Another 32 bit register with RW bitfields straddling byte boundaries"
+  },
+  {
+   "offset": 8,
+   "name": "REG_THREE", "typeRef": "REG_RW_WITH_BITFIELDS_STRADDLING_BYTE_BOUNDARIES_0",
+   "comment": "32 bit register with RW bitfields straddling byte boundaries"
+  },
+  {
+   "offset": 12,
+   "name": "REG_FOUR", "typeRef": "REG_RW_WITH_BITFIELDS_STRADDLING_BYTE_BOUNDARIES_1",
+   "comment": "Another 32 bit register with RW bitfields straddling byte boundaries"
+  }
+ ],
+ "regTypes": [
+  {
+   "typeRef": "REG_RW_WITH_BITFIELDS_STRADDLING_BYTE_BOUNDARIES_0",
+   "width": 32,
+   "fields": [
+    {"bits": [3, 0], "name": "NIBBLE", "mode": "RW", "resetVal": 0},
+    {"bits": [11, 4], "name": "MISALIGNED_BYTE_0", "mode": "RW", "resetVal": 0},
+    {"bits": [19, 12], "name": "MISALIGNED_BYTE_1", "mode": "RW", "resetVal": 0},
+    {"bits": [31, 20], "name": "REST_OF_BITS", "mode": "RW", "resetVal": 0}
+   ],
+   "comment": "32 bit register with misaligned nibbles and bytes"
+  },
+  {
+   "typeRef": "REG_RW_WITH_BITFIELDS_STRADDLING_BYTE_BOUNDARIES_1",
+   "width": 32,
+   "fields": [
+    {"bits": [23, 0], "name": "THREE_BYTE_BITFIELD", "mode": "RW", "resetVal": 0},
+    {"bits": [31, 24], "name": "TOP_BYTE", "mode": "RW", "resetVal": 0}
+   ],
+   "comment": "32 bit register with a three byte bitfield and a single byte"
+  }
+ ]
+}

--- a/src/test/scala/AmbaUnitTester.scala
+++ b/src/test/scala/AmbaUnitTester.scala
@@ -67,6 +67,10 @@ abstract class AmbelUnitTester(DATA_W: Int = 32) extends BaseUnitTester {
     t.rsp.pSlvErr.expect(true.B)
   }
 
+  def ApbExpectNoSlvErr(t: Apb2IO) = {
+    t.rsp.pSlvErr.expect(false.B)
+  }
+
   def ApbWriteStrb(t: Apb2IO, pclk: Clock, pAddr: Int, pWData: Int, pStrb: Int) = {
     val pAddrStr: String = f"h${pAddr}%08x"
     val pWDataStr: String = f"h${pWData}%08x"

--- a/src/test/scala/MisalignedRWRegs.scala
+++ b/src/test/scala/MisalignedRWRegs.scala
@@ -1,0 +1,23 @@
+// See README.md for license details.
+package ambel
+
+import chisel3._
+
+/** =Bundles for Connection to Apb2CSTrgt(REG_DESC_JSON="src/test/json/MisalignedRWRegs.json")=
+  *
+  * THIS IS AUTO-GENERATED CODE - DO NOT MODIFY BY HAND!
+  */
+class _MisalignedRWRegsRwVec_ extends Bundle {
+  val RegZero_Nibble = UInt(4.W)
+  val RegZero_MisalignedByte0 = UInt(8.W)
+  val RegZero_MisalignedByte1 = UInt(8.W)
+  val RegZero_RestOfBits = UInt(12.W)
+  val RegTwo_ThreeByteBitfield = UInt(24.W)
+  val RegTwo_TopByte = UInt(8.W)
+  val RegThree_Nibble = UInt(4.W)
+  val RegThree_MisalignedByte0 = UInt(8.W)
+  val RegThree_MisalignedByte1 = UInt(8.W)
+  val RegThree_RestOfBits = UInt(12.W)
+  val RegFour_ThreeByteBitfield = UInt(24.W)
+  val RegFour_TopByte = UInt(8.W)
+}


### PR DESCRIPTION
## Describe your changes
Adding tests for pStrb functionality where pSlvErr should be signalled and bit field not written _at all_ if not all pStrb bits required to cover the bit field are set.

## Issue number and link
Fixes [#11](https://github.com/richmorj/ambel/issues/11)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have followed the coding guidelines
- [x] I have added tests
